### PR TITLE
cargo: Fix package version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mercurio"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Change package version to v0.0.0 as that's our current version

Signed-off-by: Guilherme Felipe da Silva <gfsilva.eng@gmail.com>