### PR TITLE
ci: Add initial CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+language: rust
+cache: cargo
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+os:
+  - linux
+
+dist: xenial
+
+stages:
+  - format
+  - lint
+  - build
+  - test
+
+jobs:
+  fast_finish: true
+  allow_failures:
+    - rust: nightly
+
+  include:
+    - name: Format
+      stage: format
+      script:
+        - rustup component add rustfmt
+        - cargo fmt --all -- --check
+
+    - name: Lint
+      stage: lint
+      install:
+        - rustup component add clippy
+      script:
+        - cargo clippy --version
+        - cargo clippy -- -D warnings
+
+    - name: Build
+      stage: build
+      script: cargo build --release
+
+    - name: Unit test
+      stage: test
+      script:
+        - cargo test --lib
+
+    - name: Code audit
+      stage: test
+      install:
+        - cargo install cargo-audit
+      script:
+        - cargo audit
+
+    - name: Report coverage
+      stage: test
+      install:
+        - cargo install  cargo-tarpaulin
+      script:
+        - cargo tarpaulin --verbose --ciserver travis-ci --coveralls "${TRAVIS_JOB_ID}"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+[![Build Status](https://app.travis-ci.com/frenzox/mercurio.svg?branch=master)](https://app.travis-ci.com/frenzox/mercurio)
+[![Coverage Status](https://coveralls.io/repos/github/frenzox/mercurio/badge.svg?branch=master)](https://coveralls.io/github/frenzox/mercurio?branch=master)


### PR DESCRIPTION
Set up initial travis-ci pipeline that checks code format, lints it,
builds ant tests

Signed-off-by: Guilherme Felipe da Silva <gfsilva.eng@gmail.com>