### PR TITLE
general: boyscout: Avoid glob imports

### DIFF
--- a/src/packets/connack.rs
+++ b/src/packets/connack.rs
@@ -4,7 +4,24 @@ use bytes::{Buf, BufMut};
 
 use crate::control_packet::{ControlPacket, ControlPacketType};
 use crate::endec::{Decoder, DecoderWithContext, Encoder, VariableByteInteger};
-use crate::properties::*;
+use crate::properties::AssignedClientIdentifier;
+use crate::properties::AuthenticationData;
+use crate::properties::AuthenticationMethod;
+use crate::properties::MaximumPacketSize;
+use crate::properties::MaximumQoS;
+use crate::properties::Property;
+use crate::properties::ReasonString;
+use crate::properties::ReceiveMaximum;
+use crate::properties::ResponseInformation;
+use crate::properties::RetainAvailable;
+use crate::properties::ServerKeepAlive;
+use crate::properties::ServerReference;
+use crate::properties::SessionExpiryInterval;
+use crate::properties::SharedSubscriptionAvailable;
+use crate::properties::SubscriptionIdentifierAvailable;
+use crate::properties::TopicAliasMaximum;
+use crate::properties::UserProperty;
+use crate::properties::WildcardSubscriptionAvailable;
 use crate::reason::ReasonCode;
 
 #[derive(Default, Debug, PartialEq)]

--- a/src/packets/connect.rs
+++ b/src/packets/connect.rs
@@ -4,7 +4,22 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 use crate::control_packet::{ControlPacket, ControlPacketType};
 use crate::endec::{Decoder, DecoderWithContext, Encoder, VariableByteInteger};
-use crate::properties::*;
+use crate::properties::AuthenticationData;
+use crate::properties::AuthenticationMethod;
+use crate::properties::ContentType;
+use crate::properties::CorrelationData;
+use crate::properties::MaximumPacketSize;
+use crate::properties::MessageExpiryInterval;
+use crate::properties::PayloadFormatIndicator;
+use crate::properties::Property;
+use crate::properties::ReceiveMaximum;
+use crate::properties::RequestProblemInformation;
+use crate::properties::RequestResponseInformation;
+use crate::properties::ResponseTopic;
+use crate::properties::SessionExpiryInterval;
+use crate::properties::TopicAliasMaximum;
+use crate::properties::UserProperty;
+use crate::properties::WillDelayInterval;
 use crate::qos::QoS;
 use crate::reason::ReasonCode;
 

--- a/src/packets/publish.rs
+++ b/src/packets/publish.rs
@@ -2,7 +2,15 @@ use bytes::{Buf, Bytes, BytesMut};
 
 use crate::control_packet::{ControlPacket, ControlPacketType};
 use crate::endec::{Decoder, Encoder, VariableByteInteger};
-use crate::properties::*;
+use crate::properties::ContentType;
+use crate::properties::CorrelationData;
+use crate::properties::MessageExpiryInterval;
+use crate::properties::PayloadFormatIndicator;
+use crate::properties::Property;
+use crate::properties::ResponseTopic;
+use crate::properties::SubscriptionIdentifier;
+use crate::properties::TopicAlias;
+use crate::properties::UserProperty;
 use crate::qos::QoS;
 use crate::reason::ReasonCode;
 


### PR DESCRIPTION
Globbing in import statements makes the code harder to read as the
developer needs to make some effor to find out where a type is coming
from, wheareas leaving the import explicity helps with that.

Signed-off-by: Guilherme Felipe da Silva <gfsilva.eng@gmail.com>