### PR TITLE
general: Improve naming

### DIFF
--- a/src/endec.rs
+++ b/src/endec.rs
@@ -6,7 +6,7 @@ use crate::reason::ReasonCode;
 
 pub trait Encoder {
     fn encode(&self, buffer: &mut BytesMut);
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         mem::size_of_val(self)
     }
 }
@@ -78,7 +78,7 @@ impl Encoder for VariableByteInteger {
         encode_var_byte_integer(self.0, buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         match self.0 {
             0..=127 => 1,
             128..=16383 => 2,
@@ -104,7 +104,7 @@ impl Encoder for String {
         buffer.put(self.as_bytes());
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         self.len() + mem::size_of::<u16>()
     }
 }
@@ -135,7 +135,7 @@ impl Encoder for &'static str {
         buffer.put(self.as_bytes());
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         self.len() + mem::size_of::<u16>()
     }
 }
@@ -210,7 +210,7 @@ impl Encoder for Bytes {
         buffer.extend(self);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         mem::size_of::<u16>() + self.len()
     }
 }
@@ -241,9 +241,9 @@ where
         }
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         match self {
-            Some(v) => v.get_encoded_size(),
+            Some(v) => v.encoded_size(),
             None => 0,
         }
     }
@@ -259,11 +259,11 @@ where
         }
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
         for e in self {
-            len += e.get_encoded_size();
+            len += e.encoded_size();
         }
 
         len

--- a/src/packets/connack.rs
+++ b/src/packets/connack.rs
@@ -35,7 +35,7 @@ impl Encoder for ConnAckFlags {
         buffer.put_u8(flags);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         mem::size_of::<u8>()
     }
 }
@@ -96,26 +96,26 @@ impl Encoder for ConnAckProperties {
         self.authentication_data.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len: usize = 0;
 
-        len += self.session_expiry_interval.get_encoded_size();
-        len += self.receive_maximum.get_encoded_size();
-        len += self.maximum_qos.get_encoded_size();
-        len += self.retain_available.get_encoded_size();
-        len += self.maximum_packet_size.get_encoded_size();
-        len += self.assigned_client_id.get_encoded_size();
-        len += self.topic_alias_max.get_encoded_size();
-        len += self.reason_string.get_encoded_size();
-        len += self.user_property.get_encoded_size();
-        len += self.wildcard_subscription_available.get_encoded_size();
-        len += self.subscription_identifier_available.get_encoded_size();
-        len += self.shared_subscription_available.get_encoded_size();
-        len += self.server_keepalive.get_encoded_size();
-        len += self.response_information.get_encoded_size();
-        len += self.server_reference.get_encoded_size();
-        len += self.authentication_method.get_encoded_size();
-        len += self.authentication_data.get_encoded_size();
+        len += self.session_expiry_interval.encoded_size();
+        len += self.receive_maximum.encoded_size();
+        len += self.maximum_qos.encoded_size();
+        len += self.retain_available.encoded_size();
+        len += self.maximum_packet_size.encoded_size();
+        len += self.assigned_client_id.encoded_size();
+        len += self.topic_alias_max.encoded_size();
+        len += self.reason_string.encoded_size();
+        len += self.user_property.encoded_size();
+        len += self.wildcard_subscription_available.encoded_size();
+        len += self.subscription_identifier_available.encoded_size();
+        len += self.shared_subscription_available.encoded_size();
+        len += self.server_keepalive.encoded_size();
+        len += self.response_information.encoded_size();
+        len += self.server_reference.encoded_size();
+        len += self.authentication_method.encoded_size();
+        len += self.authentication_data.encoded_size();
 
         len
     }
@@ -252,11 +252,10 @@ impl Encoder for ConnAckPacket {
 
         // Fixed header
         buffer.put_u8((Self::PACKET_TYPE as u8) << 4);
-        remaining_len += self.flags.get_encoded_size();
-        remaining_len += self.reason_code.get_encoded_size();
-        remaining_len +=
-            VariableByteInteger(self.properties.get_encoded_size() as u32).get_encoded_size();
-        remaining_len += self.properties.get_encoded_size();
+        remaining_len += self.flags.encoded_size();
+        remaining_len += self.reason_code.encoded_size();
+        remaining_len += VariableByteInteger(self.properties.encoded_size() as u32).encoded_size();
+        remaining_len += self.properties.encoded_size();
         VariableByteInteger(remaining_len as u32).encode(buffer);
 
         // Variable header
@@ -264,7 +263,7 @@ impl Encoder for ConnAckPacket {
         self.reason_code.encode(buffer);
 
         // Properties
-        VariableByteInteger(self.properties.get_encoded_size() as u32).encode(buffer);
+        VariableByteInteger(self.properties.encoded_size() as u32).encode(buffer);
         self.properties.encode(buffer);
     }
 }

--- a/src/packets/connect.rs
+++ b/src/packets/connect.rs
@@ -61,7 +61,7 @@ impl Encoder for ConnectFlags {
         buffer.put_u8(flags);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         mem::size_of::<u8>()
     }
 }
@@ -124,18 +124,18 @@ impl Encoder for ConnectProperties {
         self.authentication_data.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.session_expiry_interval.get_encoded_size();
-        len += self.receive_maximum.get_encoded_size();
-        len += self.maximum_packet_size.get_encoded_size();
-        len += self.topic_alias_maximum.get_encoded_size();
-        len += self.request_response_information.get_encoded_size();
-        len += self.request_problem_information.get_encoded_size();
-        len += self.user_property.get_encoded_size();
-        len += self.authentication_method.get_encoded_size();
-        len += self.authentication_data.get_encoded_size();
+        len += self.session_expiry_interval.encoded_size();
+        len += self.receive_maximum.encoded_size();
+        len += self.maximum_packet_size.encoded_size();
+        len += self.topic_alias_maximum.encoded_size();
+        len += self.request_response_information.encoded_size();
+        len += self.request_problem_information.encoded_size();
+        len += self.user_property.encoded_size();
+        len += self.authentication_method.encoded_size();
+        len += self.authentication_data.encoded_size();
 
         len
     }
@@ -242,16 +242,16 @@ impl Encoder for WillProperties {
         self.user_property.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.will_delay_interval.get_encoded_size();
-        len += self.payload_format_indicator.get_encoded_size();
-        len += self.message_expiry_interval.get_encoded_size();
-        len += self.content_type.get_encoded_size();
-        len += self.response_topic.get_encoded_size();
-        len += self.correlation_data.get_encoded_size();
-        len += self.user_property.get_encoded_size();
+        len += self.will_delay_interval.encoded_size();
+        len += self.payload_format_indicator.encoded_size();
+        len += self.message_expiry_interval.encoded_size();
+        len += self.content_type.encoded_size();
+        len += self.response_topic.encoded_size();
+        len += self.correlation_data.encoded_size();
+        len += self.user_property.encoded_size();
         len
     }
 }
@@ -337,8 +337,8 @@ impl Encoder for ConnectPayload {
     fn encode(&self, buffer: &mut BytesMut) {
         self.client_id.encode(buffer);
 
-        if self.will_properties.get_encoded_size() > 0 {
-            VariableByteInteger(self.will_properties.get_encoded_size() as u32).encode(buffer);
+        if self.will_properties.encoded_size() > 0 {
+            VariableByteInteger(self.will_properties.encoded_size() as u32).encode(buffer);
             self.will_properties.encode(buffer);
         }
 
@@ -348,20 +348,19 @@ impl Encoder for ConnectPayload {
         self.password.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.client_id.get_encoded_size();
-        if self.will_properties.get_encoded_size() > 0 {
-            len += VariableByteInteger(self.will_properties.get_encoded_size() as u32)
-                .get_encoded_size();
-            len += self.will_properties.get_encoded_size();
+        len += self.client_id.encoded_size();
+        if self.will_properties.encoded_size() > 0 {
+            len += VariableByteInteger(self.will_properties.encoded_size() as u32).encoded_size();
+            len += self.will_properties.encoded_size();
         }
 
-        len += self.will_topic.get_encoded_size();
-        len += self.will_payload.get_encoded_size();
-        len += self.user_name.get_encoded_size();
-        len += self.password.get_encoded_size();
+        len += self.will_topic.encoded_size();
+        len += self.will_payload.encoded_size();
+        len += self.user_name.encoded_size();
+        len += self.password.encoded_size();
 
         len
     }
@@ -416,14 +415,13 @@ impl Encoder for ConnectPacket {
 
         // Fixed header
         buffer.put_u8((Self::PACKET_TYPE as u8) << 4);
-        remaining_len += Self::PROTOCOL_NAME.get_encoded_size();
-        remaining_len += Self::PROTOCOL_VERSION.get_encoded_size();
-        remaining_len += self.flags.get_encoded_size();
-        remaining_len += self.keepalive.get_encoded_size();
-        remaining_len +=
-            VariableByteInteger(self.properties.get_encoded_size() as u32).get_encoded_size();
-        remaining_len += self.properties.get_encoded_size();
-        remaining_len += self.payload.get_encoded_size();
+        remaining_len += Self::PROTOCOL_NAME.encoded_size();
+        remaining_len += Self::PROTOCOL_VERSION.encoded_size();
+        remaining_len += self.flags.encoded_size();
+        remaining_len += self.keepalive.encoded_size();
+        remaining_len += VariableByteInteger(self.properties.encoded_size() as u32).encoded_size();
+        remaining_len += self.properties.encoded_size();
+        remaining_len += self.payload.encoded_size();
         VariableByteInteger(remaining_len as u32).encode(buffer);
 
         // Variable header
@@ -431,7 +429,7 @@ impl Encoder for ConnectPacket {
         Self::PROTOCOL_VERSION.encode(buffer);
         self.flags.encode(buffer);
         self.keepalive.encode(buffer);
-        VariableByteInteger(self.properties.get_encoded_size() as u32).encode(buffer);
+        VariableByteInteger(self.properties.encoded_size() as u32).encode(buffer);
         self.properties.encode(buffer);
 
         // Payload

--- a/src/packets/puback.rs
+++ b/src/packets/puback.rs
@@ -17,11 +17,11 @@ impl Encoder for PubAckProperties {
         self.user_property.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.reason_str.get_encoded_size();
-        len += self.user_property.get_encoded_size();
+        len += self.reason_str.encoded_size();
+        len += self.user_property.encoded_size();
 
         len
     }
@@ -80,21 +80,20 @@ impl Encoder for PubAckPacket {
 
         buffer.put_u8((Self::PACKET_TYPE as u8) << 4);
 
-        remaining_len += self.packet_id.get_encoded_size();
-        remaining_len += self.reason.get_encoded_size();
-        remaining_len +=
-            VariableByteInteger(self.properties.get_encoded_size() as u32).get_encoded_size();
-        remaining_len += self.properties.get_encoded_size();
+        remaining_len += self.packet_id.encoded_size();
+        remaining_len += self.reason.encoded_size();
+        remaining_len += VariableByteInteger(self.properties.encoded_size() as u32).encoded_size();
+        remaining_len += self.properties.encoded_size();
 
         VariableByteInteger(remaining_len as u32).encode(buffer);
 
         self.packet_id.encode(buffer);
         self.reason.encode(buffer);
-        VariableByteInteger(self.properties.get_encoded_size() as u32).encode(buffer);
+        VariableByteInteger(self.properties.encoded_size() as u32).encode(buffer);
         self.properties.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         unimplemented!()
     }
 }

--- a/src/packets/pubcomp.rs
+++ b/src/packets/pubcomp.rs
@@ -17,11 +17,11 @@ impl Encoder for PubCompProperties {
         self.user_property.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.reason_str.get_encoded_size();
-        len += self.user_property.get_encoded_size();
+        len += self.reason_str.encoded_size();
+        len += self.user_property.encoded_size();
 
         len
     }
@@ -80,21 +80,20 @@ impl Encoder for PubCompPacket {
 
         buffer.put_u8((Self::PACKET_TYPE as u8) << 4);
 
-        remaining_len += self.packet_id.get_encoded_size();
-        remaining_len += self.reason.get_encoded_size();
-        remaining_len +=
-            VariableByteInteger(self.properties.get_encoded_size() as u32).get_encoded_size();
-        remaining_len += self.properties.get_encoded_size();
+        remaining_len += self.packet_id.encoded_size();
+        remaining_len += self.reason.encoded_size();
+        remaining_len += VariableByteInteger(self.properties.encoded_size() as u32).encoded_size();
+        remaining_len += self.properties.encoded_size();
 
         VariableByteInteger(remaining_len as u32).encode(buffer);
 
         self.packet_id.encode(buffer);
         self.reason.encode(buffer);
-        VariableByteInteger(self.properties.get_encoded_size() as u32).encode(buffer);
+        VariableByteInteger(self.properties.encoded_size() as u32).encode(buffer);
         self.properties.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         unimplemented!()
     }
 }

--- a/src/packets/publish.rs
+++ b/src/packets/publish.rs
@@ -38,17 +38,17 @@ impl Encoder for PublishProperties {
         self.content_type.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.payload_format_indicator.get_encoded_size();
-        len += self.message_expiry_interval.get_encoded_size();
-        len += self.topic_alias.get_encoded_size();
-        len += self.response_topic.get_encoded_size();
-        len += self.correlation_data.get_encoded_size();
-        len += self.user_property.get_encoded_size();
-        len += self.subscription_identifier.get_encoded_size();
-        len += self.content_type.get_encoded_size();
+        len += self.payload_format_indicator.encoded_size();
+        len += self.message_expiry_interval.encoded_size();
+        len += self.topic_alias.encoded_size();
+        len += self.response_topic.encoded_size();
+        len += self.correlation_data.encoded_size();
+        len += self.user_property.encoded_size();
+        len += self.subscription_identifier.encoded_size();
+        len += self.content_type.encoded_size();
         len
     }
 }
@@ -152,11 +152,10 @@ impl Encoder for PublishPacket {
         fixed_header |= self.retain as u8;
         fixed_header.encode(buffer);
 
-        remaining_len += self.topic_name.get_encoded_size();
-        remaining_len += self.packet_id.get_encoded_size();
-        remaining_len +=
-            VariableByteInteger(self.properties.get_encoded_size() as u32).get_encoded_size();
-        remaining_len += self.properties.get_encoded_size();
+        remaining_len += self.topic_name.encoded_size();
+        remaining_len += self.packet_id.encoded_size();
+        remaining_len += VariableByteInteger(self.properties.encoded_size() as u32).encoded_size();
+        remaining_len += self.properties.encoded_size();
 
         if let Some(payload) = &self.payload {
             remaining_len += payload.len();
@@ -167,7 +166,7 @@ impl Encoder for PublishPacket {
         // Variable header
         self.topic_name.encode(buffer);
         self.packet_id.encode(buffer);
-        VariableByteInteger(self.properties.get_encoded_size() as u32).encode(buffer);
+        VariableByteInteger(self.properties.encoded_size() as u32).encode(buffer);
         self.properties.encode(buffer);
 
         // Payload. Here it goes raw, shouldn't be encoded
@@ -193,10 +192,10 @@ impl Decoder for PublishPacket {
 
         // Payload
         let payload_len = remaining_len
-            - (topic_name.get_encoded_size()
-                + packet_id.get_encoded_size()
-                + properties.get_encoded_size()
-                + VariableByteInteger(properties.get_encoded_size() as u32).get_encoded_size());
+            - (topic_name.encoded_size()
+                + packet_id.encoded_size()
+                + properties.encoded_size()
+                + VariableByteInteger(properties.encoded_size() as u32).encoded_size());
 
         if buffer.remaining() != payload_len {
             return Err(ReasonCode::MalformedPacket);

--- a/src/packets/pubrec.rs
+++ b/src/packets/pubrec.rs
@@ -17,11 +17,11 @@ impl Encoder for PubRecProperties {
         self.user_property.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.reason_str.get_encoded_size();
-        len += self.user_property.get_encoded_size();
+        len += self.reason_str.encoded_size();
+        len += self.user_property.encoded_size();
 
         len
     }
@@ -80,21 +80,20 @@ impl Encoder for PubRecPacket {
 
         buffer.put_u8((Self::PACKET_TYPE as u8) << 4);
 
-        remaining_len += self.packet_id.get_encoded_size();
-        remaining_len += self.reason.get_encoded_size();
-        remaining_len +=
-            VariableByteInteger(self.properties.get_encoded_size() as u32).get_encoded_size();
-        remaining_len += self.properties.get_encoded_size();
+        remaining_len += self.packet_id.encoded_size();
+        remaining_len += self.reason.encoded_size();
+        remaining_len += VariableByteInteger(self.properties.encoded_size() as u32).encoded_size();
+        remaining_len += self.properties.encoded_size();
 
         VariableByteInteger(remaining_len as u32).encode(buffer);
 
         self.packet_id.encode(buffer);
         self.reason.encode(buffer);
-        VariableByteInteger(self.properties.get_encoded_size() as u32).encode(buffer);
+        VariableByteInteger(self.properties.encoded_size() as u32).encode(buffer);
         self.properties.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         unimplemented!()
     }
 }

--- a/src/packets/pubrel.rs
+++ b/src/packets/pubrel.rs
@@ -17,11 +17,11 @@ impl Encoder for PubRelProperties {
         self.user_property.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.reason_str.get_encoded_size();
-        len += self.user_property.get_encoded_size();
+        len += self.reason_str.encoded_size();
+        len += self.user_property.encoded_size();
 
         len
     }
@@ -80,21 +80,20 @@ impl Encoder for PubRelPacket {
 
         buffer.put_u8(((Self::PACKET_TYPE as u8) << 4) | 0x02);
 
-        remaining_len += self.packet_id.get_encoded_size();
-        remaining_len += self.reason.get_encoded_size();
-        remaining_len +=
-            VariableByteInteger(self.properties.get_encoded_size() as u32).get_encoded_size();
-        remaining_len += self.properties.get_encoded_size();
+        remaining_len += self.packet_id.encoded_size();
+        remaining_len += self.reason.encoded_size();
+        remaining_len += VariableByteInteger(self.properties.encoded_size() as u32).encoded_size();
+        remaining_len += self.properties.encoded_size();
 
         VariableByteInteger(remaining_len as u32).encode(buffer);
 
         self.packet_id.encode(buffer);
         self.reason.encode(buffer);
-        VariableByteInteger(self.properties.get_encoded_size() as u32).encode(buffer);
+        VariableByteInteger(self.properties.encoded_size() as u32).encode(buffer);
         self.properties.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         unimplemented!()
     }
 }

--- a/src/packets/suback.rs
+++ b/src/packets/suback.rs
@@ -19,11 +19,11 @@ impl Encoder for SubAckProperties {
         self.user_property.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.reason_string.get_encoded_size();
-        len += self.user_property.get_encoded_size();
+        len += self.reason_string.encoded_size();
+        len += self.user_property.encoded_size();
 
         len
     }
@@ -82,10 +82,10 @@ impl Encoder for SubAckPayload {
         self.reason_code.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.reason_code.get_encoded_size();
+        len += self.reason_code.encoded_size();
 
         len
     }
@@ -115,16 +115,15 @@ impl Encoder for SubAckPacket {
         fixed_header = (Self::PACKET_TYPE as u8) << 4;
         fixed_header.encode(buffer);
 
-        remaining_len += self.packet_id.get_encoded_size();
-        remaining_len +=
-            VariableByteInteger(self.properties.get_encoded_size() as u32).get_encoded_size();
-        remaining_len += self.properties.get_encoded_size();
-        remaining_len += self.payload.get_encoded_size();
+        remaining_len += self.packet_id.encoded_size();
+        remaining_len += VariableByteInteger(self.properties.encoded_size() as u32).encoded_size();
+        remaining_len += self.properties.encoded_size();
+        remaining_len += self.payload.encoded_size();
 
         VariableByteInteger(remaining_len as u32).encode(buffer);
 
         self.packet_id.encode(buffer);
-        VariableByteInteger(self.properties.get_encoded_size() as u32).encode(buffer);
+        VariableByteInteger(self.properties.encoded_size() as u32).encode(buffer);
         self.properties.encode(buffer);
         self.payload.encode(buffer);
     }

--- a/src/packets/subscribe.rs
+++ b/src/packets/subscribe.rs
@@ -20,11 +20,11 @@ impl Encoder for SubscribeProperties {
         self.user_property.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.subscription_id.get_encoded_size();
-        len += self.user_property.get_encoded_size();
+        len += self.subscription_id.encoded_size();
+        len += self.user_property.encoded_size();
 
         len
     }
@@ -121,7 +121,7 @@ impl Encoder for SubscriptionOptions {
         buffer.put_u8(encoded);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         std::mem::size_of::<u8>()
     }
 }
@@ -165,11 +165,11 @@ impl Encoder for SubscribePayload {
         self.subs_opt.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.topic_filter.get_encoded_size();
-        len += self.subs_opt.get_encoded_size();
+        len += self.topic_filter.encoded_size();
+        len += self.subs_opt.encoded_size();
 
         len
     }
@@ -204,16 +204,15 @@ impl Encoder for SubscribePacket {
         fixed_header |= 0b0000_0010;
         fixed_header.encode(buffer);
 
-        remaining_len += self.packet_id.get_encoded_size();
-        remaining_len +=
-            VariableByteInteger(self.properties.get_encoded_size() as u32).get_encoded_size();
-        remaining_len += self.properties.get_encoded_size();
-        remaining_len += self.payload.get_encoded_size();
+        remaining_len += self.packet_id.encoded_size();
+        remaining_len += VariableByteInteger(self.properties.encoded_size() as u32).encoded_size();
+        remaining_len += self.properties.encoded_size();
+        remaining_len += self.payload.encoded_size();
 
         VariableByteInteger(remaining_len as u32).encode(buffer);
 
         self.packet_id.encode(buffer);
-        VariableByteInteger(self.properties.get_encoded_size() as u32).encode(buffer);
+        VariableByteInteger(self.properties.encoded_size() as u32).encode(buffer);
         self.properties.encode(buffer);
         self.payload.encode(buffer);
     }

--- a/src/packets/unsubscribe.rs
+++ b/src/packets/unsubscribe.rs
@@ -16,10 +16,10 @@ impl Encoder for UnsubscribeProperties {
         self.user_property.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.user_property.get_encoded_size();
+        len += self.user_property.encoded_size();
 
         len
     }
@@ -74,10 +74,10 @@ impl Encoder for UnsubscribePayload {
         self.topic_filter.encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         let mut len = 0;
 
-        len += self.topic_filter.get_encoded_size();
+        len += self.topic_filter.encoded_size();
 
         len
     }
@@ -108,16 +108,15 @@ impl Encoder for UnsubscribePacket {
         fixed_header |= 0b0000_0010;
         fixed_header.encode(buffer);
 
-        remaining_len += self.packet_id.get_encoded_size();
-        remaining_len +=
-            VariableByteInteger(self.properties.get_encoded_size() as u32).get_encoded_size();
-        remaining_len += self.properties.get_encoded_size();
-        remaining_len += self.payload.get_encoded_size();
+        remaining_len += self.packet_id.encoded_size();
+        remaining_len += VariableByteInteger(self.properties.encoded_size() as u32).encoded_size();
+        remaining_len += self.properties.encoded_size();
+        remaining_len += self.payload.encoded_size();
 
         VariableByteInteger(remaining_len as u32).encode(buffer);
 
         self.packet_id.encode(buffer);
-        VariableByteInteger(self.properties.get_encoded_size() as u32).encode(buffer);
+        VariableByteInteger(self.properties.encoded_size() as u32).encode(buffer);
         self.properties.encode(buffer);
         self.payload.encode(buffer);
     }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -43,7 +43,7 @@ impl Encoder for Property {
         buffer.put_u8(*self as u8);
     }
 
-    fn get_encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> usize {
         mem::size_of::<u8>()
     }
 }
@@ -105,13 +105,13 @@ macro_rules! endecable_property {
                 )*
             }
 
-            fn get_encoded_size(&self) -> usize {
+            fn encoded_size(&self) -> usize {
                 let mut len = 0;
 
-                len += Property::$t.get_encoded_size();
+                len += Property::$t.encoded_size();
 
                 $(
-                    len += self.$n.get_encoded_size();
+                    len += self.$n.encoded_size();
                 )*
 
                 len

--- a/src/reason.rs
+++ b/src/reason.rs
@@ -111,8 +111,8 @@ impl Encoder for ReasonCode {
         self.get_code().encode(buffer);
     }
 
-    fn get_encoded_size(&self) -> usize {
-        self.get_code().get_encoded_size()
+    fn encoded_size(&self) -> usize {
+        self.get_code().encoded_size()
     }
 }
 


### PR DESCRIPTION
To follow idiomatic rust, let's not prefix getters with 'get'

Signed-off-by: Guilherme Felipe da Silva <gfsilva.eng@gmail.com>