### PR TITLE
endec: Decoder: Improve decoder

### DIFF
--- a/src/packets/pubcomp.rs
+++ b/src/packets/pubcomp.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, BufMut, BytesMut};
 
 use crate::control_packet::{ControlPacket, ControlPacketType};
-use crate::endec::{Decoder, DecoderWithContext, Encoder, VariableByteInteger};
+use crate::endec::{Decoder, Encoder, VariableByteInteger};
 use crate::properties::{Property, ReasonString, UserProperty};
 use crate::reason::ReasonCode;
 
@@ -28,8 +28,13 @@ impl Encoder for PubCompProperties {
 }
 
 impl Decoder for PubCompProperties {
-    fn decode<T: Buf>(buffer: &mut T) -> Result<Option<Self>, ReasonCode> {
-        let len = VariableByteInteger::decode(buffer)?.unwrap();
+    type Context = ();
+
+    fn decode<T: Buf>(
+        buffer: &mut T,
+        _context: Option<&Self::Context>,
+    ) -> Result<Option<Self>, ReasonCode> {
+        let len = VariableByteInteger::decode(buffer, None)?.unwrap();
         if len.0 == 0 {
             return Ok(None);
         } else if (buffer.remaining() as u32) < len.0 {
@@ -40,15 +45,17 @@ impl Decoder for PubCompProperties {
         let mut puback_properties = PubCompProperties::default();
 
         loop {
-            let p = Property::decode(&mut encoded_properties)?.unwrap();
+            let p = Property::decode(&mut encoded_properties, None)?.unwrap();
 
             match p {
                 Property::ReasonString => {
-                    puback_properties.reason_str = ReasonString::decode(&mut encoded_properties)?
+                    puback_properties.reason_str =
+                        ReasonString::decode(&mut encoded_properties, None)?
                 }
 
                 Property::UserProperty => {
-                    let user_property = UserProperty::decode(&mut encoded_properties)?.unwrap();
+                    let user_property =
+                        UserProperty::decode(&mut encoded_properties, None)?.unwrap();
 
                     if let Some(v) = &mut puback_properties.user_property {
                         v.push(user_property);
@@ -99,12 +106,17 @@ impl Encoder for PubCompPacket {
 }
 
 impl Decoder for PubCompPacket {
-    fn decode<T: Buf>(buffer: &mut T) -> Result<Option<Self>, ReasonCode> {
+    type Context = ();
+
+    fn decode<T: Buf>(
+        buffer: &mut T,
+        _context: Option<&Self::Context>,
+    ) -> Result<Option<Self>, ReasonCode> {
         buffer.advance(1);
-        let _ = VariableByteInteger::decode(buffer);
-        let packet_id = u16::decode(buffer)?.unwrap();
-        let reason = ReasonCode::decode(buffer, &Self::PACKET_TYPE)?.unwrap();
-        let properties = PubCompProperties::decode(buffer)?;
+        let _ = VariableByteInteger::decode(buffer, None);
+        let packet_id = u16::decode(buffer, None)?.unwrap();
+        let reason = ReasonCode::decode(buffer, Some(&Self::PACKET_TYPE))?.unwrap();
+        let properties = PubCompProperties::decode(buffer, None)?;
 
         Ok(Some(PubCompPacket {
             packet_id,
@@ -140,7 +152,7 @@ mod tests {
 
         let mut bytes = Bytes::from(expected);
 
-        let new_packet = PubCompPacket::decode(&mut bytes)
+        let new_packet = PubCompPacket::decode(&mut bytes, None)
             .expect("Unexpected error")
             .unwrap();
         assert_eq!(packet, new_packet);

--- a/src/packets/pubrec.rs
+++ b/src/packets/pubrec.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, BufMut, BytesMut};
 
 use crate::control_packet::{ControlPacket, ControlPacketType};
-use crate::endec::{Decoder, DecoderWithContext, Encoder, VariableByteInteger};
+use crate::endec::{Decoder, Encoder, VariableByteInteger};
 use crate::properties::{Property, ReasonString, UserProperty};
 use crate::reason::ReasonCode;
 
@@ -28,8 +28,13 @@ impl Encoder for PubRecProperties {
 }
 
 impl Decoder for PubRecProperties {
-    fn decode<T: Buf>(buffer: &mut T) -> Result<Option<Self>, ReasonCode> {
-        let len = VariableByteInteger::decode(buffer)?.unwrap();
+    type Context = ();
+
+    fn decode<T: Buf>(
+        buffer: &mut T,
+        _context: Option<&Self::Context>,
+    ) -> Result<Option<Self>, ReasonCode> {
+        let len = VariableByteInteger::decode(buffer, None)?.unwrap();
         if len.0 == 0 {
             return Ok(None);
         } else if (buffer.remaining() as u32) < len.0 {
@@ -40,15 +45,17 @@ impl Decoder for PubRecProperties {
         let mut puback_properties = PubRecProperties::default();
 
         loop {
-            let p = Property::decode(&mut encoded_properties)?.unwrap();
+            let p = Property::decode(&mut encoded_properties, None)?.unwrap();
 
             match p {
                 Property::ReasonString => {
-                    puback_properties.reason_str = ReasonString::decode(&mut encoded_properties)?
+                    puback_properties.reason_str =
+                        ReasonString::decode(&mut encoded_properties, None)?
                 }
 
                 Property::UserProperty => {
-                    let user_property = UserProperty::decode(&mut encoded_properties)?.unwrap();
+                    let user_property =
+                        UserProperty::decode(&mut encoded_properties, None)?.unwrap();
 
                     if let Some(v) = &mut puback_properties.user_property {
                         v.push(user_property);
@@ -99,12 +106,17 @@ impl Encoder for PubRecPacket {
 }
 
 impl Decoder for PubRecPacket {
-    fn decode<T: Buf>(buffer: &mut T) -> Result<Option<Self>, ReasonCode> {
+    type Context = ();
+
+    fn decode<T: Buf>(
+        buffer: &mut T,
+        _context: Option<&Self::Context>,
+    ) -> Result<Option<Self>, ReasonCode> {
         buffer.advance(1);
-        let _ = VariableByteInteger::decode(buffer);
-        let packet_id = u16::decode(buffer)?.unwrap();
-        let reason = ReasonCode::decode(buffer, &Self::PACKET_TYPE)?.unwrap();
-        let properties = PubRecProperties::decode(buffer)?;
+        let _ = VariableByteInteger::decode(buffer, None);
+        let packet_id = u16::decode(buffer, None)?.unwrap();
+        let reason = ReasonCode::decode(buffer, Some(&Self::PACKET_TYPE))?.unwrap();
+        let properties = PubRecProperties::decode(buffer, None)?;
 
         Ok(Some(PubRecPacket {
             packet_id,
@@ -140,7 +152,7 @@ mod tests {
 
         let mut bytes = Bytes::from(expected);
 
-        let new_packet = PubRecPacket::decode(&mut bytes)
+        let new_packet = PubRecPacket::decode(&mut bytes, None)
             .expect("Unexpected error")
             .unwrap();
         assert_eq!(packet, new_packet);

--- a/src/packets/pubrel.rs
+++ b/src/packets/pubrel.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, BufMut, BytesMut};
 
 use crate::control_packet::{ControlPacket, ControlPacketType};
-use crate::endec::{Decoder, DecoderWithContext, Encoder, VariableByteInteger};
+use crate::endec::{Decoder, Encoder, VariableByteInteger};
 use crate::properties::{Property, ReasonString, UserProperty};
 use crate::reason::ReasonCode;
 
@@ -28,8 +28,13 @@ impl Encoder for PubRelProperties {
 }
 
 impl Decoder for PubRelProperties {
-    fn decode<T: Buf>(buffer: &mut T) -> Result<Option<Self>, ReasonCode> {
-        let len = VariableByteInteger::decode(buffer)?.unwrap();
+    type Context = ();
+
+    fn decode<T: Buf>(
+        buffer: &mut T,
+        _context: Option<&Self::Context>,
+    ) -> Result<Option<Self>, ReasonCode> {
+        let len = VariableByteInteger::decode(buffer, None)?.unwrap();
         if len.0 == 0 {
             return Ok(None);
         } else if (buffer.remaining() as u32) < len.0 {
@@ -40,15 +45,17 @@ impl Decoder for PubRelProperties {
         let mut puback_properties = PubRelProperties::default();
 
         loop {
-            let p = Property::decode(&mut encoded_properties)?.unwrap();
+            let p = Property::decode(&mut encoded_properties, None)?.unwrap();
 
             match p {
                 Property::ReasonString => {
-                    puback_properties.reason_str = ReasonString::decode(&mut encoded_properties)?
+                    puback_properties.reason_str =
+                        ReasonString::decode(&mut encoded_properties, None)?
                 }
 
                 Property::UserProperty => {
-                    let user_property = UserProperty::decode(&mut encoded_properties)?.unwrap();
+                    let user_property =
+                        UserProperty::decode(&mut encoded_properties, None)?.unwrap();
 
                     if let Some(v) = &mut puback_properties.user_property {
                         v.push(user_property);
@@ -99,12 +106,17 @@ impl Encoder for PubRelPacket {
 }
 
 impl Decoder for PubRelPacket {
-    fn decode<T: Buf>(buffer: &mut T) -> Result<Option<Self>, ReasonCode> {
+    type Context = ();
+
+    fn decode<T: Buf>(
+        buffer: &mut T,
+        _context: Option<&Self::Context>,
+    ) -> Result<Option<Self>, ReasonCode> {
         buffer.advance(1);
-        let _ = VariableByteInteger::decode(buffer);
-        let packet_id = u16::decode(buffer)?.unwrap();
-        let reason = ReasonCode::decode(buffer, &Self::PACKET_TYPE)?.unwrap();
-        let properties = PubRelProperties::decode(buffer)?;
+        let _ = VariableByteInteger::decode(buffer, None);
+        let packet_id = u16::decode(buffer, None)?.unwrap();
+        let reason = ReasonCode::decode(buffer, Some(&Self::PACKET_TYPE))?.unwrap();
+        let properties = PubRelProperties::decode(buffer, None)?;
 
         Ok(Some(PubRelPacket {
             packet_id,
@@ -140,7 +152,7 @@ mod tests {
 
         let mut bytes = Bytes::from(expected);
 
-        let new_packet = PubRelPacket::decode(&mut bytes)
+        let new_packet = PubRelPacket::decode(&mut bytes, None)
             .expect("Unexpected error")
             .unwrap();
         assert_eq!(packet, new_packet);

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -49,7 +49,12 @@ impl Encoder for Property {
 }
 
 impl Decoder for Property {
-    fn decode<T: Buf>(buffer: &mut T) -> Result<Option<Self>, ReasonCode> {
+    type Context = ();
+
+    fn decode<T: Buf>(
+        buffer: &mut T,
+        _context: Option<&Self::Context>,
+    ) -> Result<Option<Self>, ReasonCode> {
         match buffer.get_u8() {
             0x01 => Ok(Some(Property::PayloadFormatIndicator)),
             0x02 => Ok(Some(Property::MessageExpiryInterval)),
@@ -119,8 +124,10 @@ macro_rules! endecable_property {
         }
 
         impl Decoder for $t {
-            fn decode<T: Buf>(buffer: &mut T) -> Result<Option<Self>, ReasonCode> {
-                Ok(Some($t::new($(<$s>::decode(buffer)?.unwrap(),)*)))
+            type Context = ();
+
+            fn decode<T: Buf>(buffer: &mut T, _context: Option<&Self::Context>) -> Result<Option<Self>, ReasonCode> {
+                Ok(Some($t::new($(<$s>::decode(buffer, None)?.unwrap(),)*)))
             }
         }
     }

--- a/src/reason.rs
+++ b/src/reason.rs
@@ -3,7 +3,7 @@ use std::{error, fmt};
 use bytes::Buf;
 
 use crate::control_packet::ControlPacketType;
-use crate::endec::{DecoderWithContext, Encoder};
+use crate::endec::{Decoder, Encoder};
 
 #[derive(Debug, PartialEq)]
 pub enum ReasonCode {
@@ -116,13 +116,14 @@ impl Encoder for ReasonCode {
     }
 }
 
-impl DecoderWithContext<ControlPacketType> for ReasonCode {
+impl Decoder for ReasonCode {
+    type Context = ControlPacketType;
     fn decode<T: Buf>(
         buffer: &mut T,
-        context: &ControlPacketType,
+        context: Option<&Self::Context>,
     ) -> Result<Option<Self>, ReasonCode> {
         let reason = match buffer.get_u8() {
-            0x00 => match context {
+            0x00 => match context.unwrap() {
                 ControlPacketType::SubAck => ReasonCode::GrantedQoS0,
                 ControlPacketType::Disconnect => ReasonCode::NormalDisconnection,
                 _ => ReasonCode::Success,


### PR DESCRIPTION
Due to the fact that some types are decoded differently depending on the
packet and other context information, it was previously created two
different traits, Decoder and DecoderWithContext. While that solution
solved the issue at hand at the moment, it would be inconvenient for
feature use where constraining generics to the Decoder trait would not
be possible. To overcome this limitation, the DecoderWithContext trait
was removed and now only the Decoder trait is available. This was
possible thanks to associated types.

This is still probably not the best solution as most of the times the
context is not required and we're now forced to pass None as argument in
those calls, making it very unecessarily verbose. IMHO still better than
having different traits.

Signed-off-by: Guilherme Felipe da Silva <gfsilva.eng@gmail.com>