### PR TITLE
errors: Use thiserror crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "async-stream",
  "bytes",
  "rand",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -328,6 +329,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 async-stream = "0.3"
 bytes = "1.0"
 rand = "0.8"
+thiserror = "1.0.34"
 tokio = { version = "1.17", features = ["full"] }
 tokio-stream = { version = "0.1.8", features = ["time", "sync"] }
 tracing = "0.1"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -63,7 +63,7 @@ fn decode_var_byte_integer<T: Buf>(encoded: &mut T) -> crate::Result<VariableByt
     Ok(VariableByteInteger(value))
 }
 
-#[derive(PartialEq, Debug, Default)]
+#[derive(PartialEq, Eq, Debug, Default)]
 pub struct VariableByteInteger(pub u32);
 
 impl Encoder for VariableByteInteger {

--- a/src/control_packet.rs
+++ b/src/control_packet.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 #[repr(u8)]
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum ControlPacket {
     Connect(ConnectPacket),
     ConnAck(ConnAckPacket),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,20 +1,15 @@
+use thiserror::Error;
+
 use crate::reason::ReasonCode;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
+    #[error("Packet is not complete")]
     PacketIncomplete,
-    Io(std::io::Error),
-    MQTTReasonCode(ReasonCode),
-}
 
-impl From<ReasonCode> for Error {
-    fn from(err: ReasonCode) -> Self {
-        Error::MQTTReasonCode(err)
-    }
-}
+    #[error("I/O Error: {0}")]
+    Io(#[from] std::io::Error),
 
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Self {
-        Error::Io(err)
-    }
+    #[error("MQTT Error: {0}")]
+    MQTTReasonCode(#[from] ReasonCode),
 }

--- a/src/packets/auth.rs
+++ b/src/packets/auth.rs
@@ -7,7 +7,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, PartialEq, Debug)]
+#[derive(Default, PartialEq, Eq, Debug)]
 pub struct AuthProperties {
     auth_method: Option<AuthenticationMethod>,
     auth_data: Option<AuthenticationData>,
@@ -71,7 +71,7 @@ impl Decoder for AuthProperties {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct AuthPacket {
     reason: ReasonCode,
     properties: AuthProperties,

--- a/src/packets/connack.rs
+++ b/src/packets/connack.rs
@@ -9,7 +9,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct ConnAckFlags {
     pub session_present: bool,
 }
@@ -39,7 +39,7 @@ impl Decoder for ConnAckFlags {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct ConnAckProperties {
     pub session_expiry_interval: Option<SessionExpiryInterval>,
     pub receive_maximum: Option<ReceiveMaximum>,
@@ -161,7 +161,7 @@ impl Decoder for ConnAckProperties {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, Eq, PartialEq)]
 pub struct ConnAckPacket {
     pub flags: ConnAckFlags,
     pub reason_code: ReasonCode,

--- a/src/packets/connect.rs
+++ b/src/packets/connect.rs
@@ -10,7 +10,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct ConnectFlags {
     pub user_name: bool,
     pub password: bool,
@@ -85,7 +85,7 @@ impl Decoder for ConnectFlags {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct ConnectProperties {
     pub session_expiry_interval: Option<SessionExpiryInterval>,
     pub receive_maximum: Option<ReceiveMaximum>,
@@ -168,7 +168,7 @@ impl Decoder for ConnectProperties {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct WillProperties {
     pub will_delay_interval: Option<WillDelayInterval>,
     pub payload_format_indicator: Option<PayloadFormatIndicator>,
@@ -245,7 +245,7 @@ impl Decoder for WillProperties {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, Eq, PartialEq)]
 pub struct ConnectPayload {
     pub client_id: String,
     pub will_properties: Option<WillProperties>,
@@ -299,7 +299,7 @@ impl Decoder for ConnectPayload {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct ConnectPacket {
     pub flags: ConnectFlags,
     pub keepalive: u16,

--- a/src/packets/disconnect.rs
+++ b/src/packets/disconnect.rs
@@ -7,7 +7,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, PartialEq, Debug)]
+#[derive(Default, PartialEq, Eq, Debug)]
 pub struct DisconnectProperties {
     session_expiry_interval: Option<SessionExpiryInterval>,
     reason_string: Option<ReasonString>,
@@ -71,7 +71,7 @@ impl Decoder for DisconnectProperties {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct DisconnectPacket {
     pub(crate) reason: ReasonCode,
     pub(crate) properties: Option<DisconnectProperties>,

--- a/src/packets/pingreq.rs
+++ b/src/packets/pingreq.rs
@@ -2,7 +2,7 @@ use bytes::{Buf, BufMut, BytesMut};
 
 use crate::codec::{Decoder, Encoder, VariableByteInteger};
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct PingReqPacket {}
 
 const PACKET_TYPE: u8 = 0x0c;

--- a/src/packets/pingresp.rs
+++ b/src/packets/pingresp.rs
@@ -2,7 +2,7 @@ use bytes::{Buf, BufMut, BytesMut};
 
 use crate::codec::{Decoder, Encoder, VariableByteInteger};
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct PingRespPacket {}
 
 const PACKET_TYPE: u8 = 0x0d;

--- a/src/packets/puback.rs
+++ b/src/packets/puback.rs
@@ -7,7 +7,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct PubAckProperties {
     reason_string: Option<ReasonString>,
     user_property: Option<Vec<UserProperty>>,
@@ -63,7 +63,7 @@ impl Decoder for PubAckProperties {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct PubAckPacket {
     packet_id: u16,
     reason: ReasonCode,

--- a/src/packets/pubcomp.rs
+++ b/src/packets/pubcomp.rs
@@ -7,7 +7,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct PubCompProperties {
     reason_string: Option<ReasonString>,
     user_property: Option<Vec<UserProperty>>,
@@ -63,7 +63,7 @@ impl Decoder for PubCompProperties {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct PubCompPacket {
     packet_id: u16,
     reason: ReasonCode,

--- a/src/packets/publish.rs
+++ b/src/packets/publish.rs
@@ -8,7 +8,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct PublishProperties {
     payload_format_indicator: Option<PayloadFormatIndicator>,
     message_expiry_interval: Option<MessageExpiryInterval>,
@@ -87,7 +87,7 @@ impl Decoder for PublishProperties {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct PublishPacket {
     pub(crate) dup: bool,
     pub(crate) qos_level: QoS,

--- a/src/packets/pubrec.rs
+++ b/src/packets/pubrec.rs
@@ -7,7 +7,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct PubRecProperties {
     reason_string: Option<ReasonString>,
     user_property: Option<Vec<UserProperty>>,
@@ -63,7 +63,7 @@ impl Decoder for PubRecProperties {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct PubRecPacket {
     packet_id: u16,
     reason: ReasonCode,

--- a/src/packets/pubrel.rs
+++ b/src/packets/pubrel.rs
@@ -7,7 +7,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct PubRelProperties {
     reason_string: Option<ReasonString>,
     user_property: Option<Vec<UserProperty>>,
@@ -63,7 +63,7 @@ impl Decoder for PubRelProperties {
     }
 }
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct PubRelPacket {
     packet_id: u16,
     reason: ReasonCode,

--- a/src/packets/suback.rs
+++ b/src/packets/suback.rs
@@ -7,7 +7,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct SubAckProperties {
     reason_string: Option<ReasonString>,
     user_property: Option<Vec<UserProperty>>,
@@ -63,7 +63,7 @@ impl Decoder for SubAckProperties {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SubAckPayload {
     pub(crate) reason_code: ReasonCode,
 }
@@ -90,7 +90,7 @@ impl Decoder for SubAckPayload {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SubAckPacket {
     pub(crate) packet_id: u16,
     pub(crate) properties: Option<SubAckProperties>,

--- a/src/packets/subscribe.rs
+++ b/src/packets/subscribe.rs
@@ -7,7 +7,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct SubscribeProperties {
     subscription_id: Option<SubscriptionIdentifier>,
     user_property: Option<Vec<UserProperty>>,
@@ -63,7 +63,7 @@ impl Decoder for SubscribeProperties {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum RetainHandling {
     SendRetained = 0x00,
@@ -83,7 +83,7 @@ impl From<u8> for RetainHandling {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SubscriptionOptions {
     qos: QoS,
     no_local: bool,
@@ -140,7 +140,7 @@ impl Decoder for SubscriptionOptions {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SubscribePayload {
     pub(crate) topic_filter: String,
     pub(crate) subs_opt: SubscriptionOptions,
@@ -174,7 +174,7 @@ impl Decoder for SubscribePayload {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SubscribePacket {
     pub(crate) packet_id: u16,
     pub(crate) properties: Option<SubscribeProperties>,

--- a/src/packets/unsuback.rs
+++ b/src/packets/unsuback.rs
@@ -7,7 +7,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct UnsubAckProperties {
     reason_string: Option<ReasonString>,
     user_property: Option<Vec<UserProperty>>,
@@ -63,7 +63,7 @@ impl Decoder for UnsubAckProperties {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct UnsubAckPayload {
     reason_code: ReasonCode,
 }
@@ -90,7 +90,7 @@ impl Decoder for UnsubAckPayload {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct UnsubAckPacket {
     packet_id: u16,
     properties: Option<UnsubAckProperties>,

--- a/src/packets/unsubscribe.rs
+++ b/src/packets/unsubscribe.rs
@@ -7,7 +7,7 @@ use crate::{
     reason::ReasonCode,
 };
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct UnsubscribeProperties {
     user_property: Option<Vec<UserProperty>>,
 }
@@ -59,7 +59,7 @@ impl Decoder for UnsubscribeProperties {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct UnsubscribePayload {
     topic_filter: String,
 }
@@ -86,7 +86,7 @@ impl Decoder for UnsubscribePayload {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct UnsubscribePacket {
     packet_id: u16,
     properties: Option<UnsubscribeProperties>,

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -7,7 +7,7 @@ use crate::{
 
 macro_rules! def_prop {
     ($t:ident {$i:ident: $a:expr, $($n:tt: $s:ty),*})  => {
-        #[derive(Debug, Default, PartialEq)]
+        #[derive(Debug, Default, PartialEq, Eq)]
         pub struct $t {$($n: $s,)*}
 
         impl $t {
@@ -185,7 +185,7 @@ def_prop!(SharedSubscriptionAvailable {
     value: bool
 });
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 #[allow(clippy::enum_variant_names)] // Warns because of UserProperty
 pub enum Property {
     PayloadFormatIndicator(PayloadFormatIndicator),

--- a/src/reason.rs
+++ b/src/reason.rs
@@ -1,55 +1,144 @@
-use std::{error, fmt};
-
 use bytes::Buf;
+use thiserror::Error;
 
 use crate::codec::{Decoder, Encoder};
 
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Default)]
 pub enum ReasonCode {
+    #[default]
+    #[error("Success")]
     Success,
+
+    #[error("NormalDisconnection")]
     NormalDisconnection,
+
+    #[error("Granted QoS 0")]
     GrantedQoS0,
+
+    #[error("Granted QoS 1")]
     GrantedQoS1,
+
+    #[error("Granted QoS 2")]
     GrantedQoS2,
+
+    #[error("Disconnect with Will Message")]
     DisconnectWithWillMessage,
+
+    #[error("No matching subscribers")]
     NoMatchingSubscribers,
+
+    #[error("No subscription existed")]
     NoSubscriptionExisted,
+
+    #[error("Continue authentication")]
     ContinueAuthentication,
+
+    #[error("Re-authenticate")]
     ReAuthenticate,
+
+    #[error("Unspecified error")]
     UnspecifiedError,
+
+    #[error("Malformed packet")]
     MalformedPacket,
+
+    #[error("Protocol error")]
     ProtocolError,
+
+    #[error("Implementation specific error")]
     ImplementationSpecificError,
+
+    #[error("Unsupported protocol version")]
     UnsupportedProtocolVersion,
+
+    #[error("Client identifier not valid")]
     ClientIdentifierNotValid,
+
+    #[error("Bad User Name or Password")]
     BadUserNameOrPassword,
+
+    #[error("Not authorized")]
     NotAuthorized,
+
+    #[error("Server unavailable")]
     ServerUnavailable,
+
+    #[error("Server busy")]
     ServerBusy,
+
+    #[error("Banned")]
     Banned,
+
+    #[error("Server shutting down")]
     ServerShuttingDown,
+
+    #[error("Bad authentication method")]
     BadAuthenticationMethod,
+
+    #[error("Keep Alive timeout")]
     KeepAliveTimeout,
+
+    #[error("Session taken over")]
     SessionTakenOver,
+
+    #[error("Topic filter invalid")]
     TopicFilterInvalid,
+
+    #[error("Topic name invalid")]
     TopicNameInvalid,
+
+    #[error("Packet identifier in use")]
     PacketIdentifierInUse,
+
+    #[error("Packet identifier not found")]
     PacketIdentifierNotFound,
+
+    #[error("Receive maximum exceeded")]
     ReceiveMaximumExceeded,
+
+    #[error("Topic alias invalid")]
     TopicAliasInvalid,
+
+    #[error("Packet too large")]
     PacketTooLarge,
+
+    #[error("Message rate too high")]
     MessageRateTooHigh,
+
+    #[error("Quota exceeded")]
     QuotaExceeded,
+
+    #[error("Administrative action")]
     AdministrativeAction,
+
+    #[error("Payload format invalid")]
     PayloadFormatInvalid,
+
+    #[error("Retain not supported")]
     RetainNotSupported,
+
+    #[error("QoS not supported")]
     QoSNotSupported,
+
+    #[error("User another server")]
     UseAnotherServer,
+
+    #[error("Server moved")]
     ServerMoved,
+
+    #[error("Shared subscriptions not supported")]
     SharedSubscriptionsNotSupported,
+
+    #[error("Connection rate exceeded")]
     ConnectionRateExceeded,
+
+    #[error("Maximum connect time")]
     MaximumConnectTime,
+
+    #[error("Subscription indentifiers not supported")]
     SubscriptionIdentifiersNotSupported,
+
+    #[error("Wildcard subscriptions not supported")]
     WildcardSubscriptionsNotSupported,
 }
 
@@ -169,72 +258,5 @@ impl Decoder for ReasonCode {
         };
 
         Ok(reason)
-    }
-}
-
-impl Default for ReasonCode {
-    fn default() -> Self {
-        ReasonCode::Success
-    }
-}
-
-impl error::Error for ReasonCode {}
-impl fmt::Display for ReasonCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use ReasonCode::*;
-
-        match *self {
-            Success => write!(f, "Succcess"),
-            NormalDisconnection => write!(f, "Normal disconnection"),
-            GrantedQoS0 => write!(f, "Granted QoS 0"),
-            GrantedQoS1 => write!(f, "Granted QoS 1"),
-            GrantedQoS2 => write!(f, "Granted QoS 2"),
-            DisconnectWithWillMessage => write!(f, "Disconnect with Will Message"),
-            NoMatchingSubscribers => write!(f, "No matching subscribers"),
-            NoSubscriptionExisted => write!(f, "No subscriptions existed"),
-            ContinueAuthentication => write!(f, "Continue authentication"),
-            ReAuthenticate => write!(f, "Re-authenticate"),
-            UnspecifiedError => write!(f, "Unspecified error"),
-            MalformedPacket => write!(f, "Malformed packet"),
-            ProtocolError => writeln!(f, "Protocol error"),
-            ImplementationSpecificError => write!(f, "Implementation specific error"),
-            UnsupportedProtocolVersion => write!(f, "Unsupported protocol version"),
-            ClientIdentifierNotValid => write!(f, "Client identifier not valid"),
-            BadUserNameOrPassword => write!(f, "Bad User Name or Password"),
-            NotAuthorized => write!(f, "Not authorized"),
-            ServerUnavailable => write!(f, "Server unavailable"),
-            ServerBusy => write!(f, "Server busy"),
-            Banned => write!(f, "Banned"),
-            ServerShuttingDown => write!(f, "Server shutting down"),
-            BadAuthenticationMethod => write!(f, "Bad authentication method"),
-            KeepAliveTimeout => write!(f, "Keep Alive timeout"),
-            SessionTakenOver => write!(f, "Session taken over"),
-            TopicFilterInvalid => write!(f, "Topic filter invalid"),
-            TopicNameInvalid => write!(f, "Topic name invalid"),
-            PacketIdentifierInUse => write!(f, "Packet identifier in use"),
-            PacketIdentifierNotFound => write!(f, "Packet identifier not found"),
-            ReceiveMaximumExceeded => write!(f, "Receive maximum exceeded"),
-            TopicAliasInvalid => write!(f, "Topic alias invalid"),
-            PacketTooLarge => write!(f, "Packet too large"),
-            MessageRateTooHigh => write!(f, "Message rate too high"),
-            QuotaExceeded => write!(f, "Quota exceeded"),
-            AdministrativeAction => write!(f, "Administrative action"),
-            PayloadFormatInvalid => write!(f, "Payload format invalid"),
-            RetainNotSupported => write!(f, "Retain not supported"),
-            QoSNotSupported => write!(f, "QoS not supported"),
-            UseAnotherServer => write!(f, "User another server"),
-            ServerMoved => write!(f, "Server moved"),
-            SharedSubscriptionsNotSupported => {
-                write!(f, "Shared subscriptions not supported")
-            }
-            ConnectionRateExceeded => write!(f, "Connection rate exceeded"),
-            MaximumConnectTime => write!(f, "Maximum connect time"),
-            SubscriptionIdentifiersNotSupported => {
-                write!(f, "Subscription indentifiers not supported")
-            }
-            WildcardSubscriptionsNotSupported => {
-                write!(f, "Wildcard subscriptions not supported")
-            }
-        }
     }
 }

--- a/src/reason.rs
+++ b/src/reason.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::codec::{Decoder, Encoder};
 
-#[derive(Error, Debug, PartialEq, Default)]
+#[derive(Error, Debug, PartialEq, Eq, Default)]
 pub enum ReasonCode {
     #[default]
     #[error("Success")]


### PR DESCRIPTION
In order to ease development and add less boilerplate, thiserror crate can help in defining and converting errors.

Signed-off-by: Guilherme Felipe da Silva <gfsilva.eng@gmail.com>